### PR TITLE
Add PyTorch version upper bound

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 This repo holds the code of TransFuse: Fusing Transformers and CNNs for Medical Image Segmentation
 
 ## Requirements
-* Pytorch>=1.6.0 (>=1.1.0 should work but not tested)
+* Pytorch>=1.6.0, <1.9.0 (>=1.1.0 should work but not tested)
 * timm==0.3.2
 
 


### PR DESCRIPTION
`timm==0.3.2` requires torch version less than 1.9 because timm depends on torch's internal collection_abcs in `torch._six`:

https://github.com/rwightman/pytorch-image-models/blob/2ed8f247154870be7acc1908fde0a7f457f67456/timm/models/layers/helpers.py#L6

which was removed in torch 1.9:

https://github.com/pytorch/pytorch/blob/v1.9.0/torch/_six.py



