### PR TITLE
Add large models and modify download link of resnet34

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ GPUs of memory>=4G shall be sufficient for this experiment.
 
 3. Training:
 	+ downloading DeiT-small from [DeiT repo](https://github.com/facebookresearch/deit) to `./pretrained`.
-	+ downloading resnet-34 from [timm Pytorch](https://github.com/rwightman/pytorch-image-models/releases/download/v0.1-weights/resnet34-43635321.pth) to `./pretrained`.
+	+ downloading resnet-34 from [timm Pytorch](https://download.pytorch.org/models/resnet34-333f7ec4.pth) to `./pretrained`.
 	+ run `train_isic.py`; you may also want to change the default saving path or other hparams as well.
 
 

--- a/lib/DeiT.py
+++ b/lib/DeiT.py
@@ -61,3 +61,45 @@ def deit_small_patch16_224(pretrained=False, **kwargs):
     model.pos_embed = nn.Parameter(pe)
     model.head = nn.Identity()
     return model
+
+
+@register_model
+def deit_base_patch16_224(pretrained=False, **kwargs):
+    model = DeiT(
+        patch_size=16, embed_dim=768, depth=12, num_heads=12, mlp_ratio=4, qkv_bias=True,
+        norm_layer=partial(nn.LayerNorm, eps=1e-6), **kwargs)
+    model.default_cfg = _cfg()
+    if pretrained:
+        ckpt = torch.load('pretrained/deit_base_patch16_224-b5f2ef4d.pth')
+        model.load_state_dict(ckpt['model'], strict=False)
+
+    pe = model.pos_embed[:, 1:, :].detach()
+    pe = pe.transpose(-1, -2)
+    pe = pe.view(pe.shape[0], pe.shape[1], int(np.sqrt(pe.shape[2])), int(np.sqrt(pe.shape[2])))
+    pe = F.interpolate(pe, size=(12, 16), mode='bilinear', align_corners=True)
+    pe = pe.flatten(2)
+    pe = pe.transpose(-1, -2)
+    model.pos_embed = nn.Parameter(pe)
+    model.head = nn.Identity()
+    return model
+
+
+@register_model
+def deit_base_patch16_384(pretrained=False, **kwargs):
+    model = DeiT(
+        img_size=384, patch_size=16, embed_dim=768, depth=12, num_heads=12, mlp_ratio=4, qkv_bias=True,
+        norm_layer=partial(nn.LayerNorm, eps=1e-6), **kwargs)
+    model.default_cfg = _cfg()
+    if pretrained:
+        ckpt = torch.load('pretrained/deit_base_patch16_384-8de9b5d1.pth')
+        model.load_state_dict(ckpt["model"])
+
+    pe = model.pos_embed[:, 1:, :].detach()
+    pe = pe.transpose(-1, -2)
+    pe = pe.view(pe.shape[0], pe.shape[1], int(np.sqrt(pe.shape[2])), int(np.sqrt(pe.shape[2])))
+    pe = F.interpolate(pe, size=(24, 32), mode='bilinear', align_corners=True)
+    pe = pe.flatten(2)
+    pe = pe.transpose(-1, -2)
+    model.pos_embed = nn.Parameter(pe)
+    model.head = nn.Identity()
+    return model

--- a/lib/TransFuse.py
+++ b/lib/TransFuse.py
@@ -1,7 +1,10 @@
 import torch
 import torch.nn as nn
-from torchvision.models import resnet34 as resnet
+from torchvision.models import resnet34
+from torchvision.models import resnet50
 from .DeiT import deit_small_patch16_224 as deit
+from .DeiT import deit_base_patch16_224 as deit_base
+from .DeiT import deit_base_patch16_384 as deit_base_384
 from torch.nn import CrossEntropyLoss, Dropout, Softmax, Linear, Conv2d, LayerNorm
 import torch.nn.functional as F
 import numpy as np
@@ -72,7 +75,7 @@ class TransFuse_S(nn.Module):
     def __init__(self, num_classes=1, drop_rate=0.2, normal_init=True, pretrained=False):
         super(TransFuse_S, self).__init__()
 
-        self.resnet = resnet()
+        self.resnet = resnet34()
         if pretrained:
             self.resnet.load_state_dict(torch.load('pretrained/resnet34-333f7ec4.pth'))
         self.resnet.fc = nn.Identity()
@@ -150,9 +153,217 @@ class TransFuse_S(nn.Module):
         x_c_2 = self.up_c_2_2(x_c_1, x_c_2_1) # joint predict low supervise here
 
         # decoder part
-        map_x = F.interpolate(self.final_x(x_c), scale_factor=16, mode='bilinear')
-        map_1 = F.interpolate(self.final_1(x_b_2), scale_factor=4, mode='bilinear')
-        map_2 = F.interpolate(self.final_2(x_c_2), scale_factor=4, mode='bilinear')
+        map_x = F.interpolate(self.final_x(x_c), scale_factor=16, mode='bilinear', align_corners=True)
+        map_1 = F.interpolate(self.final_1(x_b_2), scale_factor=4, mode='bilinear', align_corners=True)
+        map_2 = F.interpolate(self.final_2(x_c_2), scale_factor=4, mode='bilinear', align_corners=True)
+        return map_x, map_1, map_2
+
+    def init_weights(self):
+        self.up1.apply(init_weights)
+        self.up2.apply(init_weights)
+        self.final_x.apply(init_weights)
+        self.final_1.apply(init_weights)
+        self.final_2.apply(init_weights)
+        self.up_c.apply(init_weights)
+        self.up_c_1_1.apply(init_weights)
+        self.up_c_1_2.apply(init_weights)
+        self.up_c_2_1.apply(init_weights)
+        self.up_c_2_2.apply(init_weights)
+
+
+class TransFuse_L(nn.Module):
+    def __init__(self, num_classes=1, drop_rate=0.2, normal_init=True, pretrained=False):
+        super(TransFuse_L, self).__init__()
+
+        self.resnet = resnet50()
+        if pretrained:
+            self.resnet.load_state_dict(torch.load('pretrained/resnet50-19c8e357.pth'))
+        self.resnet.fc = nn.Identity()
+        self.resnet.layer4 = nn.Identity()
+
+        self.transformer = deit_base(pretrained=pretrained)
+
+        self.up1 = Up(in_ch1=768, out_ch=512)
+        self.up2 = Up(512, 256)
+
+        self.final_x = nn.Sequential(
+            Conv(1024, 256, 1, bn=True, relu=True),
+            Conv(256, 256, 3, bn=True, relu=True),
+            Conv(256, num_classes, 3, bn=False, relu=False)
+            )
+
+        self.final_1 = nn.Sequential(
+            Conv(256, 256, 3, bn=True, relu=True),
+            Conv(256, num_classes, 3, bn=False, relu=False)
+            )
+
+        self.final_2 = nn.Sequential(
+            Conv(256, 256, 3, bn=True, relu=True),
+            Conv(256, num_classes, 3, bn=False, relu=False)
+            )
+
+        self.up_c = BiFusion_block(ch_1=1024, ch_2=768, r_2=4, ch_int=1024, ch_out=1024, drop_rate=drop_rate/2)
+
+        self.up_c_1_1 = BiFusion_block(ch_1=512, ch_2=512, r_2=2, ch_int=512, ch_out=512, drop_rate=drop_rate/2)
+        self.up_c_1_2 = Up(in_ch1=1024, out_ch=512, in_ch2=512, attn=True)
+
+        self.up_c_2_1 = BiFusion_block(ch_1=256, ch_2=256, r_2=1, ch_int=256, ch_out=256, drop_rate=drop_rate/2)
+        self.up_c_2_2 = Up(512, 256, 256, attn=True)
+
+        self.drop = nn.Dropout2d(drop_rate)
+
+        if normal_init:
+            self.init_weights()
+
+    def forward(self, imgs, labels=None):
+        # bottom-up path
+        x_b = self.transformer(imgs)
+        x_b = torch.transpose(x_b, 1, 2)
+        x_b = x_b.view(x_b.shape[0], -1, 12, 16)
+        x_b = self.drop(x_b)
+
+        x_b_1 = self.up1(x_b)
+        x_b_1 = self.drop(x_b_1)
+
+        x_b_2 = self.up2(x_b_1)  # transformer pred supervise here
+        x_b_2 = self.drop(x_b_2)
+
+
+        # top-down path
+        x_u = self.resnet.conv1(imgs)
+        x_u = self.resnet.bn1(x_u)
+        x_u = self.resnet.relu(x_u)
+        x_u = self.resnet.maxpool(x_u)
+
+        x_u_2 = self.resnet.layer1(x_u)
+        x_u_2 = self.drop(x_u_2)
+
+        x_u_1 = self.resnet.layer2(x_u_2)
+        x_u_1 = self.drop(x_u_1)
+
+        x_u = self.resnet.layer3(x_u_1)
+        x_u = self.drop(x_u)
+
+
+        # joint path
+        x_c = self.up_c(x_u, x_b)
+
+        x_c_1_1 = self.up_c_1_1(x_u_1, x_b_1)
+        x_c_1 = self.up_c_1_2(x_c, x_c_1_1)
+
+        x_c_2_1 = self.up_c_2_1(x_u_2, x_b_2)
+        x_c_2 = self.up_c_2_2(x_c_1, x_c_2_1) # joint predict low supervise here
+
+
+        # decoder part
+        map_x = F.interpolate(self.final_x(x_c), scale_factor=16, mode='bilinear', align_corners=True)
+        map_1 = F.interpolate(self.final_1(x_b_2), scale_factor=4, mode='bilinear', align_corners=True)
+        map_2 = F.interpolate(self.final_2(x_c_2), scale_factor=4, mode='bilinear', align_corners=True)
+
+        return map_x, map_1, map_2
+
+    def init_weights(self):
+        self.up1.apply(init_weights)
+        self.up2.apply(init_weights)
+        self.final_x.apply(init_weights)
+        self.final_1.apply(init_weights)
+        self.final_2.apply(init_weights)
+        self.up_c.apply(init_weights)
+        self.up_c_1_1.apply(init_weights)
+        self.up_c_1_2.apply(init_weights)
+        self.up_c_2_1.apply(init_weights)
+        self.up_c_2_2.apply(init_weights)
+        
+
+class TransFuse_L_384(nn.Module):
+    def __init__(self, num_classes=1, drop_rate=0.2, normal_init=True, pretrained=False):
+        super(TransFuse_L_384, self).__init__()
+
+        self.resnet = resnet50()
+        if pretrained:
+            self.resnet.load_state_dict(torch.load('pretrained/resnet50-19c8e357.pth'))
+        self.resnet.fc = nn.Identity()
+        self.resnet.layer4 = nn.Identity()
+
+        self.transformer = deit_base_384(pretrained=pretrained)
+
+        self.up1 = Up(in_ch1=768, out_ch=512)
+        self.up2 = Up(512, 256)
+
+        self.final_x = nn.Sequential(
+            Conv(1024, 256, 1, bn=True, relu=True),
+            Conv(256, 256, 3, bn=True, relu=True),
+            Conv(256, num_classes, 3, bn=False, relu=False)
+            )
+
+        self.final_1 = nn.Sequential(
+            Conv(256, 256, 3, bn=True, relu=True),
+            Conv(256, num_classes, 3, bn=False, relu=False)
+            )
+
+        self.final_2 = nn.Sequential(
+            Conv(256, 256, 3, bn=True, relu=True),
+            Conv(256, num_classes, 3, bn=False, relu=False)
+            )
+
+        self.up_c = BiFusion_block(ch_1=1024, ch_2=768, r_2=4, ch_int=1024, ch_out=1024, drop_rate=drop_rate/2)
+
+        self.up_c_1_1 = BiFusion_block(ch_1=512, ch_2=512, r_2=2, ch_int=512, ch_out=512, drop_rate=drop_rate/2)
+        self.up_c_1_2 = Up(in_ch1=1024, out_ch=512, in_ch2=512, attn=True)
+
+        self.up_c_2_1 = BiFusion_block(ch_1=256, ch_2=256, r_2=1, ch_int=256, ch_out=256, drop_rate=drop_rate/2)
+        self.up_c_2_2 = Up(512, 256, 256, attn=True)
+
+        self.drop = nn.Dropout2d(drop_rate)
+
+        if normal_init:
+            self.init_weights()
+
+    def forward(self, imgs, labels=None):
+        # bottom-up path
+        x_b = self.transformer(imgs)
+        x_b = torch.transpose(x_b, 1, 2)
+        x_b = x_b.view(x_b.shape[0], -1, 24, 32)
+        x_b = self.drop(x_b)
+
+        x_b_1 = self.up1(x_b)
+        x_b_1 = self.drop(x_b_1)
+
+        x_b_2 = self.up2(x_b_1)  # transformer pred supervise here
+        x_b_2 = self.drop(x_b_2)
+
+
+        # top-down path
+        x_u = self.resnet.conv1(imgs)
+        x_u = self.resnet.bn1(x_u)
+        x_u = self.resnet.relu(x_u)
+        x_u = self.resnet.maxpool(x_u)
+
+        x_u_2 = self.resnet.layer1(x_u)
+        x_u_2 = self.drop(x_u_2)
+
+        x_u_1 = self.resnet.layer2(x_u_2)
+        x_u_1 = self.drop(x_u_1)
+
+        x_u = self.resnet.layer3(x_u_1)
+        x_u = self.drop(x_u)
+
+
+        # joint path
+        x_c = self.up_c(x_u, x_b)
+
+        x_c_1_1 = self.up_c_1_1(x_u_1, x_b_1)
+        x_c_1 = self.up_c_1_2(x_c, x_c_1_1)
+
+        x_c_2_1 = self.up_c_2_1(x_u_2, x_b_2)
+        x_c_2 = self.up_c_2_2(x_c_1, x_c_2_1) # joint predict low supervise here
+
+
+        # decoder part
+        map_x = F.interpolate(self.final_x(x_c), scale_factor=16, mode='bilinear', align_corners=True)
+        map_1 = F.interpolate(self.final_1(x_b_2), scale_factor=4, mode='bilinear', align_corners=True)
+        map_2 = F.interpolate(self.final_2(x_c_2), scale_factor=4, mode='bilinear', align_corners=True)
+
         return map_x, map_1, map_2
 
     def init_weights(self):
@@ -214,8 +425,11 @@ class Up(nn.Module):
             diffY = torch.tensor([x2.size()[2] - x1.size()[2]])
             diffX = torch.tensor([x2.size()[3] - x1.size()[3]])
 
-            x1 = F.pad(x1, [diffX // 2, diffX - diffX // 2,
-                            diffY // 2, diffY - diffY // 2])
+            # x1 = F.pad(x1, [diffX // 2, diffX - diffX // 2,
+            #                 diffY // 2, diffY - diffY // 2])
+            x1 = F.pad(x1,
+                       [torch.div(diffX, 2, rounding_mode='trunc'), diffX - torch.div(diffX, 2, rounding_mode='trunc'),
+                        torch.div(diffY, 2, rounding_mode='trunc'), diffY - torch.div(diffY, 2, rounding_mode='trunc')])
 
             if self.attn_block is not None:
                 x2 = self.attn_block(x1, x2)

--- a/lib/TransFuse.py
+++ b/lib/TransFuse.py
@@ -425,11 +425,8 @@ class Up(nn.Module):
             diffY = torch.tensor([x2.size()[2] - x1.size()[2]])
             diffX = torch.tensor([x2.size()[3] - x1.size()[3]])
 
-            # x1 = F.pad(x1, [diffX // 2, diffX - diffX // 2,
-            #                 diffY // 2, diffY - diffY // 2])
-            x1 = F.pad(x1,
-                       [torch.div(diffX, 2, rounding_mode='trunc'), diffX - torch.div(diffX, 2, rounding_mode='trunc'),
-                        torch.div(diffY, 2, rounding_mode='trunc'), diffY - torch.div(diffY, 2, rounding_mode='trunc')])
+            x1 = F.pad(x1, [diffX // 2, diffX - diffX // 2,
+                            diffY // 2, diffY - diffY // 2])
 
             if self.attn_block is not None:
                 x2 = self.attn_block(x1, x2)

--- a/process.py
+++ b/process.py
@@ -8,8 +8,8 @@ mask_f = ['ISIC-2017_Training_Part1_GroundTruth/', 'ISIC-2017_Validation_Part1_G
 set_size = [2000, 150, 600]
 save_name = ['train', 'val', 'test']
 
-height = 192
-width = 256
+height = 192 # 384
+width = 256 # 512
 
 for j in range(3):
 

--- a/test_isic.py
+++ b/test_isic.py
@@ -2,7 +2,7 @@ import torch
 import torch.nn.functional as F
 import numpy as np
 import os, argparse
-from lib.TransFuse import TransFuse_S
+from lib.TransFuse import TransFuse_S, TransFuse_L, TransFuse_L_384
 from utils.dataloader import test_dataset
 import imageio
 

--- a/train_isic.py
+++ b/train_isic.py
@@ -2,7 +2,7 @@ import torch
 from torch.autograd import Variable
 import argparse
 from datetime import datetime
-from lib.TransFuse import TransFuse_S
+from lib.TransFuse import TransFuse_S, TransFuse_L, TransFuse_L_384
 from utils.dataloader import get_loader, test_dataset
 from utils.utils import AvgMeter
 import torch.nn.functional as F


### PR DESCRIPTION
Hello, your work helps me a lot while doing my research!

To make this code easier to use, I made these changes:
1. Add Large scale models, TransFuse_L, TransFuse_L_384, which were mentioned in the paper.
2. Modify the download link of resnet34 in README, because the link writen in lib/TransFuse.py was different from the one in README.
3. Add `align_corners=True` to `F.interpolate`, in order to avoid such WARNING
```
/usr/local/miniconda3/lib/python3.7/site-packages/torch/nn/functional.py:3455: UserWarning: Default upsampling behavior when mode=bilinear is changed to align_corners=False since 0.4.0. Please specify align_corners=True if the old behavior is desired. See the documentation of nn.Upsample for details.
  "See the documentation of nn.Upsample for details.".format(mode)
```